### PR TITLE
Update blog_post.md

### DIFF
--- a/blog_post.md
+++ b/blog_post.md
@@ -212,7 +212,7 @@ through the OpenSearch Service Serverless console as described below.
     </figure>
 
 3.  Set the vector index name as `sagemaker-readthedocs-io`, vector
-    field name as `vector` dimensions as `1536`, and distance metric as
+    field name as `vector` dimensions as `1536`, choose  engine types as `FAISS` and distance metric as
     `Euclidean`. **It is required that you set these parameters exactly
     as mentioned here because the Bedrock Knowledge Base Agent is going
     to use these same values**.


### PR DESCRIPTION
Based on new Bedrock requirements engine types should be FAISS -----
The knowledge base storage configuration provided is invalid... The OpenSearch Serverless engine type associated with your vector index is invalid. Recreate your vector index with one of the following valid engine types: FAISS. Then retry your request.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
