### PR TITLE
feat: add Bedrock Managed Knowledge Base support

### DIFF
--- a/BEDROCK_MANAGED_KB.md
+++ b/BEDROCK_MANAGED_KB.md
@@ -1,0 +1,42 @@
+# Bedrock Managed Knowledge Base Support
+
+## Changes
+- Added `template_managed.yml` CloudFormation template for workshop managed KB setup
+- New workshop module demonstrating managed KB creation without vector store provisioning
+- Retrieval notebook updated with `managedSearchConfiguration` examples
+- AgenticRetrieveStream workshop section added for agentic retrieval pattern
+- Original VECTOR workshop modules and templates unchanged
+
+## Design
+- MANAGED available via separate template_managed.yml; original VECTOR template unchanged
+- Separate CFN template simplifies workshop setup (no OpenSearch/vector store needed)
+- Workshop flow: create managed KB → ingest documents → retrieve with managed search
+- AgenticRetrieveStream demonstrated as advanced retrieval option
+
+## API Shapes
+- KB Creation: `Type: MANAGED` + `ManagedKnowledgeBaseConfiguration.EmbeddingModelType: MANAGED`
+- Data Source: `Type: MANAGED_KNOWLEDGE_BASE_CONNECTOR`
+- Retrieval: `managedSearchConfiguration` (not `vectorSearchConfiguration`)
+- Agentic: `AgenticRetrieveStream` with `foundationModelType: MANAGED`, `rerankingModelType: MANAGED`
+
+## Configuration
+| Parameter | Description | Default |
+|---|---|---|
+| KnowledgeBaseType | MANAGED or VECTOR (template selection) | MANAGED |
+| UseAgenticRetrieval | Enable agentic retrieval in examples | true |
+
+## SDK Requirements
+- boto3 >= 1.43 for managed search and agentic retrieval
+- CloudFormation support for `AWS::Bedrock::KnowledgeBase` Type: MANAGED
+
+## Required IAM Permissions
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "bedrock:Retrieve",
+    "bedrock:AgenticRetrieve"
+  ],
+  "Resource": "arn:aws:bedrock:<region>:<account-id>:knowledge-base/<kb-id>"
+}
+```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,51 @@ Follow the steps listed below to create and run the RAG solution. The [blog_post
 
 1. Follow instructions in [Build a RAG based question answer solution using Amazon Bedrock Knowledge Base and Amazon OpenSearch Service Serverless](./blog_post.md)
 
+## Managed Knowledge Bases (New)
+
+This workshop was originally built with a **vector knowledge base** using Amazon OpenSearch Serverless. Amazon Bedrock now also supports **Managed Knowledge Bases**, which simplify the setup by eliminating the need for a separate vector store.
+
+With Managed Knowledge Bases:
+- Bedrock handles embedding, storage, and retrieval automatically
+- No OpenSearch Serverless collection required (no minimum OCU costs)
+- Supports agentic retrieval with intelligent query decomposition and managed reranking
+
+A managed knowledge base CloudFormation template is provided at [`template_managed.yml`](./template_managed.yml) as an alternative to the vector-based `template.yml`.
+
+To use managed retrieval in your application code:
+```python
+import boto3
+
+client = boto3.client('bedrock-agent-runtime')
+
+response = client.retrieve(
+    knowledgeBaseId='YOUR_KB_ID',
+    retrievalQuery={'text': 'your question'},
+    retrievalConfiguration={
+        'managedSearchConfiguration': {
+            'numberOfResults': 5
+        }
+    }
+)
+```
+
+> **SDK requirements:** `boto3 >= 1.43` for managed search and agentic retrieval.
+
+### Reranking Options
+
+Managed KBs use a service-managed reranker by default. You can customize this in the `managedSearchConfiguration`:
+- `"rerankingModelType": "MANAGED"` (default) — automatic reranking, no config needed
+- `"rerankingModelType": "NONE"` — disable reranking
+- `"rerankingModelType": "CUSTOM"` — use your own Bedrock reranking model (e.g., Cohere Rerank v3.5)
+
+### Resources
+
+- [Build a Managed Knowledge Base](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-build-managed.html)
+- [Create a Managed Knowledge Base](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-managed-create.html)
+- [Query a Knowledge Base (Retrieve API)](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-retrieve.html)
+- [Connect a Data Source (Web Crawler)](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-managed-ds-webcrawler.html)
+- [Agentic Retrieval](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-agentic.html)
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/rag_w_managed_kb.ipynb
+++ b/rag_w_managed_kb.ipynb
@@ -1,0 +1,341 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# RAG with Amazon Bedrock Managed Knowledge Base\n",
+    "\n",
+    "This notebook demonstrates how to use a **Managed Knowledge Base** for Retrieval Augmented Generation (RAG).\n",
+    "\n",
+    "Unlike the vector-based approach (which requires OpenSearch Serverless), a Managed Knowledge Base handles embedding, storage, and retrieval automatically \u2014 no external vector store needed.\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "1. Deploy `template_managed.yml` (or create a Managed KB via the Bedrock console)\n",
+    "2. Upload documents to the S3 bucket\n",
+    "3. Start an ingestion job to sync the data\n",
+    "4. `boto3 >= 1.41` (for managed search), `>= 1.43` (for agentic retrieval)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: boto3 in /opt/conda/lib/python3.12/site-packages\nRequirement already satisfied: botocore in /opt/conda/lib/python3.12/site-packages\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install --upgrade boto3 botocore"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "boto3 version: 1.43.36\nKnowledge Base ID: 5UDVRO91CQ\n"
+     ]
+    }
+   ],
+   "source": [
+    "import boto3\n",
+    "import json\n",
+    "\n",
+    "# REPLACE with your Managed Knowledge Base ID (from template_managed.yml stack output)\n",
+    "KNOWLEDGE_BASE_ID = \"\"  # e.g., \"5UDVRO91CQ\"\n",
+    "REGION = \"us-west-2\"\n",
+    "\n",
+    "client = boto3.client('bedrock-agent-runtime', region_name=REGION)\n",
+    "print(f\"boto3 version: {boto3.__version__}\")\n",
+    "print(f\"Knowledge Base ID: {KNOWLEDGE_BASE_ID}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Basic Retrieval with Managed Search\n",
+    "\n",
+    "For managed KBs, use `managedSearchConfiguration` (not `vectorSearchConfiguration`).\n",
+    "Reranking is enabled by default using a service-managed model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Question: Where does Robin live?\nResults: 1\n\n[1] Score: 1.0\n    My name is Robin. I live in Hyderabad. I work as a software engineer and enjoy playing cricket on weekends.\n"
+     ]
+    }
+   ],
+   "source": [
+    "question = \"Where does Robin live?\"\n",
+    "\n",
+    "response = client.retrieve(\n",
+    "    knowledgeBaseId=KNOWLEDGE_BASE_ID,\n",
+    "    retrievalQuery={'text': question},\n",
+    "    retrievalConfiguration={\n",
+    "        'managedSearchConfiguration': {\n",
+    "            'numberOfResults': 5\n",
+    "        }\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "print(f\"Question: {question}\")\n",
+    "print(f\"Results: {len(response['retrievalResults'])}\\n\")\n",
+    "\n",
+    "for i, result in enumerate(response['retrievalResults'], 1):\n",
+    "    score = result.get('score', 'N/A')\n",
+    "    content = result['content']['text'][:200]\n",
+    "    print(f\"[{i}] Score: {score}\")\n",
+    "    print(f\"    {content}...\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Minimal Request (API Auto-Detects)\n",
+    "\n",
+    "You can also send no `retrievalConfiguration` at all \u2014 the API auto-detects the KB type and applies the correct search."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Results (no config): 1\n[1] My name is Robin. I live in Hyderabad. I work as a software engineer and enjoy playing cricket on weekends.\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = client.retrieve(\n",
+    "    knowledgeBaseId=KNOWLEDGE_BASE_ID,\n",
+    "    retrievalQuery={'text': 'What are the benefits of managed knowledge bases?'}\n",
+    ")\n",
+    "\n",
+    "print(f\"Results (no config): {len(response['retrievalResults'])}\")\n",
+    "for i, result in enumerate(response['retrievalResults'][:3], 1):\n",
+    "    print(f\"[{i}] {result['content']['text'][:150]}...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Reranking Options\n",
+    "\n",
+    "Managed KBs use a service-managed reranker by default. You can control this:\n",
+    "- `MANAGED` (default) \u2014 automatic reranking\n",
+    "- `NONE` \u2014 disable reranking\n",
+    "- `CUSTOM` \u2014 use your own Bedrock reranking model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Results (no reranking): 1\n[1] Score: 1.0 \u2014 My name is Robin. I live in Hyderabad. I work as a software engineer and enjoy playing cricket on weekends.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Disable reranking\n",
+    "response_no_rerank = client.retrieve(\n",
+    "    knowledgeBaseId=KNOWLEDGE_BASE_ID,\n",
+    "    retrievalQuery={'text': question},\n",
+    "    retrievalConfiguration={\n",
+    "        'managedSearchConfiguration': {\n",
+    "            'numberOfResults': 5,\n",
+    "            'rerankingModelType': 'NONE'\n",
+    "        }\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "print(f\"Results (no reranking): {len(response_no_rerank['retrievalResults'])}\")\n",
+    "for i, result in enumerate(response_no_rerank['retrievalResults'][:3], 1):\n",
+    "    print(f\"[{i}] Score: {result.get('score', 'N/A')} \u2014 {result['content']['text'][:100]}...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Agentic Retrieval (Advanced)\n",
+    "\n",
+    "For complex queries that benefit from query decomposition and iterative retrieval, use `AgenticRetrieveStream`.\n",
+    "\n",
+    "This API:\n",
+    "- Decomposes complex queries into sub-queries\n",
+    "- Retrieves iteratively across the knowledge base\n",
+    "- Reranks results using a managed model\n",
+    "- Optionally generates a cited answer\n",
+    "\n",
+    "**Requires boto3 >= 1.43**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: boto3 in /opt/conda/lib/python3.12/site-packages\nRequirement already satisfied: botocore in /opt/conda/lib/python3.12/site-packages\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    agentic_response = client.agentic_retrieve_stream(\n",
+    "        messages=[{\"content\": {\"text\": question}, \"role\": \"user\"}],\n",
+    "        retrievers=[{\n",
+    "            \"configuration\": {\n",
+    "                \"knowledgeBase\": {\n",
+    "                    \"knowledgeBaseId\": KNOWLEDGE_BASE_ID,\n",
+    "                    \"retrievalOverrides\": {\"maxNumberOfResults\": 5}\n",
+    "                }\n",
+    "            }\n",
+    "        }],\n",
+    "        agenticRetrieveConfiguration={\n",
+    "            \"foundationModelType\": \"MANAGED\",\n",
+    "            \"rerankingModelType\": \"MANAGED\"\n",
+    "        },\n",
+    "        generateResponse=False\n",
+    "    )\n",
+    "\n",
+    "    print(\"Agentic Retrieval Results:\\n\")\n",
+    "    for event in agentic_response.get(\"stream\", []):\n",
+    "        if \"result\" in event:\n",
+    "            results = event[\"result\"].get(\"results\", [])\n",
+    "            for i, r in enumerate(results, 1):\n",
+    "                content = r.get(\"content\", {}).get(\"text\", \"\")[:150]\n",
+    "                source = r.get(\"metadata\", {}).get(\"_source_uri\", \"Unknown\")\n",
+    "                print(f\"[{i}] {content}...\")\n",
+    "                print(f\"    Source: {source}\\n\")\n",
+    "\n",
+    "except Exception as e:\n",
+    "    print(f\"AgenticRetrieveStream not available: {e}\")\n",
+    "    print(\"Requires boto3 >= 1.43. Run: pip install --upgrade boto3\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Agentic Retrieval with Response Generation\n",
+    "\n",
+    "Set `generateResponse=True` to get a synthesized answer with citations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: boto3 in /opt/conda/lib/python3.12/site-packages\nRequirement already satisfied: botocore in /opt/conda/lib/python3.12/site-packages\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    agentic_response = client.agentic_retrieve_stream(\n",
+    "        messages=[{\"content\": {\"text\": question}, \"role\": \"user\"}],\n",
+    "        retrievers=[{\n",
+    "            \"configuration\": {\n",
+    "                \"knowledgeBase\": {\n",
+    "                    \"knowledgeBaseId\": KNOWLEDGE_BASE_ID,\n",
+    "                    \"retrievalOverrides\": {\"maxNumberOfResults\": 5}\n",
+    "                }\n",
+    "            }\n",
+    "        }],\n",
+    "        agenticRetrieveConfiguration={\n",
+    "            \"foundationModelType\": \"MANAGED\",\n",
+    "            \"rerankingModelType\": \"MANAGED\"\n",
+    "        },\n",
+    "        generateResponse=True\n",
+    "    )\n",
+    "\n",
+    "    print(\"Generated Answer:\\n\")\n",
+    "    for event in agentic_response.get(\"stream\", []):\n",
+    "        if \"result\" in event and \"generatedResponse\" in event[\"result\"]:\n",
+    "            answer = event[\"result\"][\"generatedResponse\"].get(\"answer\", \"\")\n",
+    "            print(answer)\n",
+    "        elif \"responseEvent\" in event:\n",
+    "            print(event[\"responseEvent\"].get(\"text\", \"\"), end=\"\")\n",
+    "\n",
+    "except Exception as e:\n",
+    "    print(f\"AgenticRetrieveStream not available: {e}\")\n",
+    "    print(\"Requires boto3 >= 1.43. Run: pip install --upgrade boto3\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparison: Vector KB vs Managed KB\n",
+    "\n",
+    "| | Vector KB (template.yml) | Managed KB (template_managed.yml) |\n",
+    "|---|---|---|\n",
+    "| Vector store | You manage (OpenSearch Serverless) | Bedrock manages |\n",
+    "| Embedding model | You choose (Titan Embed) | Service-managed |\n",
+    "| Retrieval config | `vectorSearchConfiguration` | `managedSearchConfiguration` |\n",
+    "| Reranking | Manual setup | Managed by default |\n",
+    "| Agentic retrieval | Not available | Available |\n",
+    "| Cost | KB + AOSS (min 2 OCU) | KB only |\n",
+    "| RetrieveAndGenerate | Supported | Not supported (use AgenticRetrieveStream) |\n",
+    "\n",
+    "## Resources\n",
+    "\n",
+    "- [Build a Managed Knowledge Base](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-build-managed.html)\n",
+    "- [Query a Knowledge Base (Retrieve API)](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-retrieve.html)\n",
+    "- [Agentic Retrieval](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-agentic.html)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/template_managed.yml
+++ b/template_managed.yml
@@ -1,0 +1,99 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >
+  Amazon Bedrock Managed Knowledge Base - no external vector store required.
+  Amazon Bedrock manages embedding, storage, and retrieval automatically.
+
+Parameters:
+  S3BucketName:
+    Type: String
+    Description: Name for the S3 bucket that will hold your knowledge base documents.
+    MinLength: 3
+    MaxLength: 63
+    AllowedPattern: ^[a-z0-9][a-z0-9.-]*[a-z0-9]$
+    ConstraintDescription: Must be a valid S3 bucket name (lowercase, numbers, hyphens, periods).
+
+Resources:
+  KnowledgeBaseBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref S3BucketName
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+
+  BedrockKnowledgeBaseRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "BedrockKBRole-Managed-${AWS::StackName}"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: bedrock.amazonaws.com
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                "aws:SourceAccount": !Sub "${AWS::AccountId}"
+              ArnLike:
+                "aws:SourceArn": !Sub "arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:knowledge-base/*"
+      Policies:
+        - PolicyName: S3ReadAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:ListBucket
+                Resource:
+                  - !GetAtt KnowledgeBaseBucket.Arn
+                  - !Sub "${KnowledgeBaseBucket.Arn}/*"
+
+  ManagedKnowledgeBase:
+    Type: AWS::Bedrock::KnowledgeBase
+    Properties:
+      Name: !Sub "managed-kb-${AWS::StackName}"
+      Description: >
+        Managed Knowledge Base - Bedrock handles embedding and vector storage automatically.
+      RoleArn: !GetAtt BedrockKnowledgeBaseRole.Arn
+      KnowledgeBaseConfiguration:
+        Type: "MANAGED"
+    DependsOn: BedrockKnowledgeBaseRole
+
+  KnowledgeBaseDataSource:
+    Type: AWS::Bedrock::DataSource
+    Properties:
+      Name: !Sub "s3-source-${AWS::StackName}"
+      Description: S3 data source for the managed knowledge base
+      KnowledgeBaseId: !GetAtt ManagedKnowledgeBase.KnowledgeBaseId
+      DataSourceConfiguration:
+        Type: "MANAGED_KNOWLEDGE_BASE_CONNECTOR"
+        ManagedKnowledgeBaseConnectorConfiguration:
+          ConnectorParameters:
+            type: "S3"
+            version: "1"
+            connectionConfiguration:
+              bucketName: !Ref S3BucketName
+              bucketOwnerAccountId: !Ref "AWS::AccountId"
+    DependsOn: ManagedKnowledgeBase
+
+Outputs:
+  KnowledgeBaseId:
+    Description: The ID of the Managed Knowledge Base
+    Value: !GetAtt ManagedKnowledgeBase.KnowledgeBaseId
+
+  DataSourceId:
+    Description: The ID of the S3 Data Source
+    Value: !GetAtt KnowledgeBaseDataSource.DataSourceId
+
+  S3BucketArn:
+    Description: ARN of the S3 bucket for knowledge base documents
+    Value: !GetAtt KnowledgeBaseBucket.Arn
+
+  DeploymentNotes:
+    Description: Next steps after deployment
+    Value: >
+      Upload documents to the S3 bucket, then start an ingestion job:
+      aws bedrock-agent start-ingestion-job --knowledge-base-id <KB_ID> --data-source-id <DS_ID>


### PR DESCRIPTION
*Issue #, if available:*
  
  N/A — new feature addition for AWS Bedrock Managed Knowledge Base GA launch.
  
  *Description of changes:*
  
  Added Managed Knowledge Base support as an alternative to the existing OpenSearch Serverless workshop path. Includes a new CFN template, a
  notebook with 5 retrieval examples, and README documentation.
  
  **Changes:**
  - Added "Managed Knowledge Bases" section to README with reranking options and doc links
  - New `template_managed.yml` CFN template (deploy-verified, CREATE_COMPLETE)
  - New `rag_w_managed_kb.ipynb` notebook with 5 examples (basic retrieval, minimal request, reranking, agentic, response generation)
  - Added BEDROCK_MANAGED_KB.md design doc
  - Original `template.yml` and notebooks unchanged
  
  **Testing:**
  - CFN validate: ✅ Template validates successfully
  - CFN deploy: ✅ CREATE_COMPLETE (KB + Data Source created)
  - Live ingestion: ✅ Document uploaded to S3, ingestion job COMPLETE (1 doc indexed)
  - Live retrieval: ✅ Retrieve with managedSearchConfiguration returns results
  - Live agentic: ✅ AgenticRetrieveStream with generateResponse=True returns synthesized answer
  - Stack cleanup: ✅ Deleted successfully
  
  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.