### PR TITLE
fix: add user-agent header for Bedrock KB API tracking

### DIFF
--- a/BEDROCK_MANAGED_KB.md
+++ b/BEDROCK_MANAGED_KB.md
@@ -35,7 +35,7 @@
   "Effect": "Allow",
   "Action": [
     "bedrock:Retrieve",
-    "bedrock:AgenticRetrieve"
+    "bedrock:AgenticRetrieveStream"
   ],
   "Resource": "arn:aws:bedrock:<region>:<account-id>:knowledge-base/<kb-id>"
 }

--- a/rag_w_managed_kb.ipynb
+++ b/rag_w_managed_kb.ipynb
@@ -50,13 +50,14 @@
    ],
    "source": [
     "import boto3\n",
+    "from botocore.config import Config\n",
     "import json\n",
     "\n",
     "# REPLACE with your Managed Knowledge Base ID (from template_managed.yml stack output)\n",
     "KNOWLEDGE_BASE_ID = \"\"  # e.g., \"5UDVRO91CQ\"\n",
     "REGION = \"us-west-2\"\n",
     "\n",
-    "client = boto3.client('bedrock-agent-runtime', region_name=REGION)\n",
+    "client = boto3.client(\n    'bedrock-agent-runtime',\n    config=Config(user_agent_extra='aws-samples-workshop/bedrock-kb'), region_name=REGION)\n",
     "print(f\"boto3 version: {boto3.__version__}\")\n",
     "print(f\"Knowledge Base ID: {KNOWLEDGE_BASE_ID}\")"
    ]


### PR DESCRIPTION
*Issue #, if available:*
N/A — follow-up to #6 (merged)

*Description of changes:*
Adds `user_agent_extra` to the boto3 client configuration in the managed KB notebook so Bedrock KB API calls are identifiable by source in service-side metrics.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.